### PR TITLE
Rewrite for kernel LIRC

### DIFF
--- a/ir_record.py
+++ b/ir_record.py
@@ -1,35 +1,22 @@
-"""记录红外遥控器的脉冲序列。"""
+"""Record infrared pulses via the LIRC device."""
 
 import argparse
-
-from ir_device import IRReceiver
-
-DEFAULT_PIN = 23  # 默认红外接收头的 GPIO
+from ir_device import record_pulses
 
 
-def record_ir(pin: int, timeout: float = 2.0):
-    """在给定时间内记录引脚电平变化, 返回微秒为单位的脉冲时长列表。"""
-    receiver = IRReceiver(pin)
-    try:
-        pulses = receiver.record(timeout)
-        return pulses
-    finally:
-        receiver.close()
-
-
-def main():
-    parser = argparse.ArgumentParser(description="记录红外脉冲序列")
-    parser.add_argument("--pin", type=int, default=DEFAULT_PIN, help="接收红外的GPIO")
-    parser.add_argument("--timeout", type=float, default=2.0, help="记录时长(秒)")
+def main() -> None:
+    parser = argparse.ArgumentParser(description="record IR pulses")
+    parser.add_argument("--device", default="/dev/lirc0", help="LIRC device path")
+    parser.add_argument("--timeout", type=float, default=2.0, help="record time in seconds")
     args = parser.parse_args()
 
-    print("请对准接收器按下遥控器按键...")
-    pulses = record_ir(args.pin, args.timeout)
+    pulses = record_pulses(args.device, args.timeout)
     if pulses:
         print(",".join(str(p) for p in pulses))
     else:
-        print("未检测到信号")
+        print("no signal captured")
 
 
 if __name__ == "__main__":
     main()
+

--- a/ir_recv.py
+++ b/ir_recv.py
@@ -1,32 +1,22 @@
-"""示例代码：在 Raspberry Pi 5 上接收红外信号。"""
+"""Wait for an infrared signal via the LIRC device."""
 
 import argparse
-
-from ir_device import IRReceiver
-
-DEFAULT_PIN = 23  # 默认红外接收头所在的 GPIO
+from ir_device import record_pulses
 
 
-def main():
-    parser = argparse.ArgumentParser(description="接收红外信号")
-    parser.add_argument(
-        "--pin",
-        type=int,
-        default=DEFAULT_PIN,
-        help="用于接收的 GPIO (默认: %(default)s)",
-    )
+def main() -> None:
+    parser = argparse.ArgumentParser(description="wait for IR signal")
+    parser.add_argument("--device", default="/dev/lirc0", help="LIRC device path")
+    parser.add_argument("--timeout", type=float, default=5.0, help="wait time in seconds")
     args = parser.parse_args()
 
-    receiver = IRReceiver(args.pin)
-    try:
-        print("等待信号...")
-        if receiver.wait():
-            print("检测到红外信号")
-        else:
-            print("未检测到红外信号")
-    finally:
-        receiver.close()
+    pulses = record_pulses(args.device, args.timeout)
+    if pulses:
+        print("IR signal detected")
+    else:
+        print("no signal")
 
 
 if __name__ == "__main__":
     main()
+

--- a/ir_send.py
+++ b/ir_send.py
@@ -1,27 +1,19 @@
-"""示例代码：在 Raspberry Pi 5 上发送 38kHz 红外信号。"""
+"""Send a single infrared pulse for testing."""
 
 import argparse
+from ir_device import send_pulses
 
-from ir_device import IRSender
 
-DEFAULT_PIN = 18  # 默认红外 LED 所在的 GPIO
-
-def main():
-    parser = argparse.ArgumentParser(description="发送 38kHz 红外信号")
-    parser.add_argument(
-        "--pin",
-        type=int,
-        default=DEFAULT_PIN,
-        help="用于发射的 GPIO (默认: %(default)s)",
-    )
+def main() -> None:
+    parser = argparse.ArgumentParser(description="send test pulse")
+    parser.add_argument("--device", default="/dev/lirc0", help="LIRC device path")
+    parser.add_argument("--duration", type=float, default=0.5, help="pulse duration in seconds")
+    parser.add_argument("--freq", type=int, default=38000, help="carrier frequency")
     args = parser.parse_args()
 
-    sender = IRSender(args.pin)
-    try:
-        print("发送 38kHz 脉冲...")
-        sender.send_pulse()
-    finally:
-        sender.close()
+    send_pulses([int(args.duration * 1_000_000)], args.device, args.freq)
+
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- rewrite README for gpio-ir LIRC usage
- replace lgpio-based scripts with LIRC implementations

## Testing
- `python3 -m py_compile ir_device.py ir_record.py ir_play.py ir_send.py ir_recv.py`

------
https://chatgpt.com/codex/tasks/task_e_688387be36148331ab46ca528caa996c