### PR TITLE
Update README with missing LIRC steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,26 @@
 ## 软件准备
 
 1. 在 `/boot/firmware/config.txt` 中启用覆盖：
+   ```ini
+   dtoverlay=gpio-ir,gpio_pin=23       # 接收头使用 BCM23
+   dtoverlay=gpio-ir-tx,gpio_pin=18    # 发射管使用 BCM18
    ```
-   dtoverlay=gpio-ir,gpio_pin=23
-   dtoverlay=gpio-ir-tx,gpio_pin=18
+   重启后会在 `/dev` 下生成 `lirc0`（接收）和 `lirc1`（发射）。
+2. 安装 LIRC 及 Python 绑定：
+   ```bash
+   sudo apt update
+   sudo apt install lirc python3-lirc
    ```
-2. 安装 LIRC 工具：`sudo apt install lirc`
+3. 编辑 `/etc/lirc/lirc_options.conf`，确保：
+   ```conf
+   driver = default
+   device = /dev/lirc0
+   ```
+   启用并重启服务：
+   ```bash
+   sudo systemctl enable lircd
+   sudo systemctl restart lircd
+   ```
 
 ## 录制一次
 
@@ -28,7 +43,7 @@ sudo python3 ir_record.py --device /dev/lirc0 --timeout 2 > code.txt
 ## 重复回放
 
 ```bash
-sudo python3 ir_play.py --device /dev/lirc0 "$(cat code.txt)"
+sudo python3 ir_play.py --device /dev/lirc1 --freq 38000 "$(cat code.txt)"
 ```
 
 `ir_record.py` 会输出逗号分隔的脉冲时长（单位：微秒）。
@@ -38,3 +53,12 @@ sudo python3 ir_play.py --device /dev/lirc0 "$(cat code.txt)"
 
 - `ir_send.py`：发送固定脉冲，测试发射硬件。
 - `ir_recv.py`：简单等待信号，可用于检查接收硬件。
+
+## 验证
+
+```bash
+ls /dev/lirc*
+ir-keytable
+```
+
+以上命令可检查设备是否创建并查看接收状态。


### PR DESCRIPTION
## Summary
- document LIRC overlay configuration and python bindings
- mention editing `/etc/lirc/lirc_options.conf`
- show how to replay using `/dev/lirc1`
- add simple verification commands

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68842963a15c8331929cc9a7e7767975