### PR TITLE
Add lirc key script

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ for _ in range(3):
 print("发射结束")
 ```
 
+也可以直接运行仓库提供的 `ir_send_key.py` 脚本：
+
+```bash
+python ir_send_key.py myremote KEY_POWER --count 3
+```
+
 > 前提：`myremote.conf` 已配置好，并已加载到 lircd（见前文），KEY_POWER 为有效码表按键。
 
 ---

--- a/ir_play.py
+++ b/ir_play.py
@@ -7,7 +7,7 @@ from ir_device import send_pulses
 def main() -> None:
     parser = argparse.ArgumentParser(description="play back IR pulses")
     parser.add_argument("codes", help="comma separated pulse durations")
-    parser.add_argument("--device", default="/dev/lirc0", help="LIRC device path")
+    parser.add_argument("--device", default="/dev/lirc1", help="LIRC device path")
     parser.add_argument("--freq", type=int, default=38000, help="carrier frequency")
     parser.add_argument("--duty", type=float, default=0.33, help="duty cycle (0-1)")
     args = parser.parse_args()

--- a/ir_send_key.py
+++ b/ir_send_key.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Send a configured LIRC key via the transmit device."""
+
+import argparse
+import time
+import lirc
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="send a LIRC key code")
+    parser.add_argument("remote", help="remote name defined in lircd.conf")
+    parser.add_argument("key", help="key name to send")
+    parser.add_argument(
+        "--lircd", default="/var/run/lirc/lircd", help="path to lircd socket"
+    )
+    parser.add_argument(
+        "--device", default="/dev/lirc1", help="LIRC transmit device"
+    )
+    parser.add_argument(
+        "--count", type=int, default=1, help="times to send the key"
+    )
+    parser.add_argument(
+        "--delay", type=float, default=0.0, help="delay between repeats in seconds"
+    )
+    args = parser.parse_args()
+
+    for i in range(args.count):
+        lirc.send_once(args.remote, [args.key], lircd=args.lircd, device=args.device)
+        if i < args.count - 1 and args.delay > 0:
+            time.sleep(args.delay)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add helper script `ir_send_key.py` for sending remote keys using LIRC code table
- default to `/dev/lirc1` in `ir_play.py`
- document new script usage

## Testing
- `python -m py_compile ir_send_key.py ir_play.py ir_record.py ir_device.py`

------
https://chatgpt.com/codex/tasks/task_e_688711b08e20833194874d59b157d7c4